### PR TITLE
Permit disabling serial console if there is none

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ grub_consoles:
   - tty0
   - 'ttyS0,{{ grub_serial.speed }}'
 
+grub_serial_enabled: True
+
 # grub serial command settings
 grub_serial:
   speed: 115200

--- a/templates/etc/default/grub.j2
+++ b/templates/etc/default/grub.j2
@@ -16,9 +16,12 @@ GRUB_TIMEOUT={{ grub_timeout }}
 GRUB_DISTRIBUTOR=$(lsb_release -i -s 2>/dev/null || echo {{ ansible_distribution }})
 GRUB_CMDLINE_LINUX_DEFAULT="{{ grub_console }}"
 GRUB_CMDLINE_LINUX="{{ grub_cmdline_linux | join(' ') }}"
-{% if grub_serial | d(False) %}
+{% if grub_serial_enabled == True %}
 GRUB_SERIAL_COMMAND="serial --speed={{ grub_serial.speed }} --unit={{ grub_serial.unit }} --word={{ grub_serial.word }} --parity={{ grub_serial.parity }} --stop={{ grub_serial.stop }}"
 {% endif %}
 
-# disable graphical terminal (grub-pc only)
+{% if grub_serial_enabled == True %}
+GRUB_TERMINAL="console serial"
+{% else %}
 GRUB_TERMINAL=console
+{% endif %}


### PR DESCRIPTION
##### SUMMARY
The serial console should be enabled by default, hence the introduction a default value enabling if not explicitely disabled. This does NOT change the default behaviour which is intended.

Verified with: HPE ProLiant MicroServer Gen10 which has neither
               an iLO-based BMC with virtual serial port, nor
               any physical serial port by default.
##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

(actually a bit both)
##### ANSIBLE VERSION
```
ansible 2.7.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = (removed)
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Sep 26 2018, 18:42:22) [GCC 6.3.0 20170516]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
