### PR TITLE
Feature/add grub default options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,11 +25,63 @@ may be a good idea to mention in this section that the boto package is required.
 Role Variables
 ===============
 
-A description of the settable variables for this role should go here, including
-any variables that are in defaults/main.yml, vars/main.yml, and any variables
-that can/should be set via parameters to the role. Any variables that are read
-from other roles and/or the global scope (ie. hostvars, group vars, etc.)
-should be mentioned here as well.
+start grub and linux on these consoles
+
+.. code-block:: YAML
+
+   grub_consoles:
+     - tty0
+     - 'ttyS0,{{ grub_serial.speed }}'
+
+grub serial command settings
+
+.. code-block:: YAML
+
+   grub_serial:
+     speed: 115200
+     unit: 0
+     word: 8
+     parity: 0
+     stop: 1
+
+grub timeout (in seconds)
+
+.. code-block:: YAML
+
+   grub_timeout: 5
+
+disable predictable network interface names
+
+.. code-block:: YAML
+
+   grub_disable_network_predictable_interface_names: True
+
+additional cmdline arguments
+type: list
+
+.. code-block:: YAML
+
+   grub_cmdline_linux_list: []
+
+additional cmdline default arguemnts
+type: list
+
+.. code-block:: YAML
+
+   grub_cmdline_linux_default_list: [ ]
+
+An example how to add additional parameters to the kernel:
+
+.. code-block:: YAML
+
+  grub_cmdline_linux_list:
+    - ip=192.0.2.2::192.0.2.1:255.255.255.0:host.example.com:eth0:off
+    - vnc
+    - vncpassword=password
+
+  grub_cmdline_linux_default_list:
+    - transparent_hugepage=never
+    - numa=off
 
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,10 @@ grub_disable_network_predictable_interface_names: True
 # type: list
 grub_cmdline_linux_list: []
 
+# additional cmdline default arguments
+# type: list
+grub_cmdline_linux_default_list: []
+
 # An example how to add additional parameters to the kernel:
 #
 # .. code-block:: YAML
@@ -31,3 +35,7 @@ grub_cmdline_linux_list: []
 #     - ip=192.0.2.2::192.0.2.1:255.255.255.0:host.example.com:eth0:off
 #     - vnc
 #     - vncpassword=password
+#
+#   grub_cmdline_linux_default_list:
+#     - transparent_hugepage=never
+#     - numa=off

--- a/templates/etc/default/grub.j2
+++ b/templates/etc/default/grub.j2
@@ -26,8 +26,7 @@ GRUB_CMDLINE_LINUX_DEFAULT="{{ grub_console }}"
 {% endif %}
 GRUB_CMDLINE_LINUX="{{ grub_cmdline_linux | join(' ') }}"
 {% if grub_serial | d(False) %}
-GRUB_SERIAL_COMMAND="serial --speed={{ grub_serial.speed }} --unit={{ grub_serial.unit }} --word={{ grub_serial.word }} --pari
-ty={{ grub_serial.parity }} --stop={{ grub_serial.stop }}"
+GRUB_SERIAL_COMMAND="serial --speed={{ grub_serial.speed }} --unit={{ grub_serial.unit }} --word={{ grub_serial.word }} --parity={{ grub_serial.parity }} --stop={{ grub_serial.stop }}"
 {% endif %}
 
 # disable graphical terminal (grub-pc only)

--- a/templates/etc/default/grub.j2
+++ b/templates/etc/default/grub.j2
@@ -1,6 +1,9 @@
 {% if grub_consoles | d(False) %}
 {%   set grub_console = "console=" + grub_consoles | join(' console=') %}
 {% endif %}
+{% if grub_cmdline_linux_default_list | d(False) %}
+{%   set grub_cmdline_linux_default = grub_cmdline_linux_default_list | join(' ') %}
+{% endif %}
 {% set grub_cmdline_linux = [] + grub_cmdline_linux_list %}
 {% if ansible_cmdline['rd.auto'] | d(False) %}
 {%   set grub_cmdline_linux = grub_cmdline_linux + ['rd.auto'] %}
@@ -14,10 +17,17 @@
 GRUB_DEFAULT=0
 GRUB_TIMEOUT={{ grub_timeout }}
 GRUB_DISTRIBUTOR=$(lsb_release -i -s 2>/dev/null || echo {{ ansible_distribution }})
+{% if grub_console and grub_cmdline_linux_default | d(False) %}
+GRUB_CMDLINE_LINUX_DEFAULT="{{ grub_console }} {{ grub_cmdline_linux_default }}"
+{% elif grub_cmdline_linux_default | d(False) %}
+GRUB_CMDLINE_LINUX_DEFAULT="{{ grub_cmdline_linux_default }}"
+{% else %}
 GRUB_CMDLINE_LINUX_DEFAULT="{{ grub_console }}"
+{% endif %}
 GRUB_CMDLINE_LINUX="{{ grub_cmdline_linux | join(' ') }}"
 {% if grub_serial | d(False) %}
-GRUB_SERIAL_COMMAND="serial --speed={{ grub_serial.speed }} --unit={{ grub_serial.unit }} --word={{ grub_serial.word }} --parity={{ grub_serial.parity }} --stop={{ grub_serial.stop }}"
+GRUB_SERIAL_COMMAND="serial --speed={{ grub_serial.speed }} --unit={{ grub_serial.unit }} --word={{ grub_serial.word }} --pari
+ty={{ grub_serial.parity }} --stop={{ grub_serial.stop }}"
 {% endif %}
 
 # disable graphical terminal (grub-pc only)


### PR DESCRIPTION
##### SUMMARY
Add new variable `grub_cmdline_linux_default_list` to set `GRUB_CMDLINE_LINUX_DEFAULT` in `/etc/default/grub `. For better configuration of Grub with Ansible.

Added the default variables to the Readme as well.

Backgroud: Oracle DB server on EL needs to have some kernel options set in the default as well.

#### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.9.4
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible                                            
  executable location = /usr/bin/ansible
  python version = 2.7.16 (default, Oct 10 2019, 22:02:15) [GCC 8.3.0]                                                 
```
