### PR TITLE
fixed default setting for Buster, because it is not supported anymore

### DIFF
--- a/vars/Debian_10.yml
+++ b/vars/Debian_10.yml
@@ -1,0 +1,21 @@
+---
+
+# grub related packages
+grub_packages:
+  - grub2
+
+# grub unwanted packages
+grub_packages_removed:
+  - os-prober
+
+# grub-mkconfig binary
+grub_mkconfig_bin: /usr/sbin/grub-mkconfig
+
+# grub configuration file
+grub_cfg: /etc/default/grub
+
+# grub main running configuration
+grub_boot_cfg: /boot/grub/grub.cfg
+
+# Use predictiable ifnames, because disabling is not supported anymore in Buster
+grub_disable_network_predictable_interface_names: False


### PR DESCRIPTION
##### SUMMARY

In Debian 10 - Buster, the classic interface names (`eth0`etc. ) are not supported anymore. Thus the grub setting: `net.ifnames=0` needs to be removed before upgrading to Buster or in a Buster installation itself. 

##### ISSUE TYPE
 - Bugfix Pull Request


##### ANSIBLE VERSION
```
ansible 2.9.9
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  python version = 3.7.7 (default, Jun  4 2020, 15:43:14) [GCC 9.3.1 20200408 (Red Hat 9.3.1-2)]
```


##### ADDITIONAL INFORMATION
Details about the change in Debian: https://www.debian.org/releases/stable/amd64/release-notes/ch-information.en.html#migrate-interface-names
