### PR TITLE
improved variable checking in jinja template

### DIFF
--- a/templates/etc/default/grub.j2
+++ b/templates/etc/default/grub.j2
@@ -17,11 +17,11 @@
 GRUB_DEFAULT=0
 GRUB_TIMEOUT={{ grub_timeout }}
 GRUB_DISTRIBUTOR=$(lsb_release -i -s 2>/dev/null || echo {{ ansible_distribution }})
-{% if grub_console and grub_cmdline_linux_default | d(False) %}
+{% if grub_console is defined and grub_cmdline_linux_default | d(False) %}
 GRUB_CMDLINE_LINUX_DEFAULT="{{ grub_console }} {{ grub_cmdline_linux_default }}"
 {% elif grub_cmdline_linux_default | d(False) %}
 GRUB_CMDLINE_LINUX_DEFAULT="{{ grub_cmdline_linux_default }}"
-{% else %}
+{% elif grub_console is defined | d(False) %}
 GRUB_CMDLINE_LINUX_DEFAULT="{{ grub_console }}"
 {% endif %}
 GRUB_CMDLINE_LINUX="{{ grub_cmdline_linux | join(' ') }}"


### PR DESCRIPTION
##### SUMMARY

Fixes #10 Had an unclean check if the variable was defined or not. If `grub_consoles` is empty, the `grub_console` will not be set inside the template and therefore can't be used. The else used as the last option to use `grub_console` as standalone option for `GRUB_CMDLINE_LINUX_DEFAULT=`. It was missing the state that it can be missing at all. This is now fixed. Thanks to the bug report linked.

##### ISSUE TYPE
 - Bugfix Pull Request

##### ANSIBLE VERSION
```
ansible 2.9.15
  config file = /home/haa/workspace/github/ansible/ansible.cfg
  configured module search path = [u'/home/haa/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Mar 20 2020, 17:08:22) [GCC 4.8.5 20150623 (Red Hat 4.8.5-39)]
```